### PR TITLE
Support for MQTT Based Devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # RFLink Platform
 This is a plugin for [RFLink](http://www.nemcon.nl/blog2/) integration in [Homebridge](https://github.com/nfarina/homebridge).
 
+Support for serially and mqtt connected RFLink devices.
+
+## MQTT RFLink Devices
+
+Inital support for mqtt connected RFLINK devices based on https://github.com/couin3/RFLink.  At the present time only read only sensor devices are supported.  Tested and validated devices include Temperature and Humidity Sensors.
+
 ## Install
 To install globally:
 ```
@@ -100,3 +106,11 @@ By adding `dimrange` to a channel, the brightness characteristic will be enabled
 `delay` sets the delay used between commands to avoid flooding RFLink.
 
 `repeat` sets the number of time a command is resent to RFLink. In some setups (e.g. NewKaku dimmers), this might yield undesired results.
+
+`mqttHost` - name or ip address of your mqtt host.  Required to enable mqtt device mode.
+
+`mqttTopic` - Optional topic for mqtt messages from your rflink device, defaults to `RFLink/msg`
+
+## Credits
+
+* NortherMan54 - Support for mqtt based RFLink devices, ie https://github.com/couin3/RFLink

--- a/index.js
+++ b/index.js
@@ -179,6 +179,16 @@ function RFLinkAccessory(log, config, controller) {
       service.parsePacket = this.parsePacket[channel.type];
       service.setBatteryStatus = this.setBatteryStatus;
 
+      // Burr winter is here
+      if (service.type == 'TemperatureSensor') {
+        // Burr winter is here
+        service.getCharacteristic(Characteristic.CurrentTemperature)
+          .setProps({
+            minValue: -100,
+            maxValue: 100,
+        });
+      }
+
       // if channel is of writable type
       if (service.type == 'Lightbulb' || service.type == 'Switch') {
         service.getCharacteristic(Characteristic.On).on('set', this.setOn.bind(service));
@@ -201,8 +211,8 @@ function RFLinkAccessory(log, config, controller) {
   this.informationService = new Service.AccessoryInformation();
   this.informationService
     .setCharacteristic(Characteristic.Manufacturer, "RFLink")
-    .setCharacteristic(Characteristic.Model, this.protocol);
-//    .setCharacteristic(Characteristic.SoftwareRevision, require('./package.json').version)
+    .setCharacteristic(Characteristic.Model, this.protocol)
+    .setCharacteristic(Characteristic.FirmwareRevision, require('./package.json').version);
 //    .setCharacteristic(Characteristic.Version, require('./package.json').version);
 
   this.log("Added RFLink device: %s, protocol: %s, address: %s, channels: %d", this.name, this.protocol, this.address, this.channels.length);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var inherits = require('util').inherits;
-var SerialPort = require("serialport");
 var RFLink = require('./rflink');
 var Service, Characteristic;
 var debug = process.env.hasOwnProperty('RFLINK_DEBUG') ? consoleDebug : function () {};
@@ -79,7 +78,9 @@ RFLinkPlatform.prototype._addDevices = function(bridgeConfig) {
     device: bridgeConfig.serialport || false,
     baudrate: bridgeConfig.baudrate || false,
     delayBetweenCommands: bridgeConfig.delay || false,
-    commandRepeat: bridgeConfig.repeat || false
+    commandRepeat: bridgeConfig.repeat || false,
+    mqttHost: bridgeConfig.mqttHost || false,
+    mqttTopic: bridgeConfig.mqttTopic || false
   },
   this._dataHandler.bind(this));
 
@@ -316,7 +317,7 @@ RFLinkAccessory.prototype.parsePacket.StatefulProgrammableSwitch = function(pack
       this.getCharacteristic(Characteristic.ProgrammableSwitchEvent).setValue(Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS, false, 'RFLink');
     }
   }
-};
+}; 
 
 RFLinkAccessory.prototype.parsePacket.StatelessProgrammableSwitch = function(packet) {
   if((this.channel == "none") || (packet.channel == this.channel)) {
@@ -339,8 +340,9 @@ RFLinkAccessory.prototype.parsePacket.StatelessProgrammableSwitch = function(pac
 
 RFLinkAccessory.prototype.parsePacket.TemperatureSensor = function(packet) {
   if (packet.data && packet.data.TEMP) {
-    debug("%s: Matched sensor: %s, address: %s, data: %o", this.type, packet.protocol, packet.address, packet.data);
+    debug("%s: Matched sensor: %s, address: %s, data: %o", this.name, packet.protocol, packet.address, packet.data);
     var temp = signedToFloat(packet.data.TEMP);
+    debug("%s: Setting temperature to %s", this.name, temp);
     this.getCharacteristic(Characteristic.CurrentTemperature).setValue(temp);
   }
 
@@ -349,8 +351,9 @@ RFLinkAccessory.prototype.parsePacket.TemperatureSensor = function(packet) {
 
 RFLinkAccessory.prototype.parsePacket.HumiditySensor = function(packet) {
   if (packet.data && packet.data.HUM) {
-    debug("%s: Matched sensor: %s, address: %s, data: %o", this.type, packet.protocol, packet.address, packet.data);
+    debug("%s: Matched sensor: %s, address: %s, data: %o", this.name, packet.protocol, packet.address, packet.data);
     var humidity = parseInt(packet.data.HUM, 10);
+    debug("%s: Setting humidity to %s", this.name, humidity);
     this.getCharacteristic(Characteristic.CurrentRelativeHumidity).setValue(humidity);
   }
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,26 @@
     "node": ">=8.0.0",
     "homebridge": ">=0.4.0"
   },
+  "devDependencies": {
+    "nodemon": "^2.0.4"
+  },
+  "scripts": {
+    "watch": "nodemon"
+  },
   "dependencies": {
-    "serialport": "^9.0.3",
-    "bluebird": "^3.3.4"
+    "@serialport/parser-readline": "^9.0.1",
+    "bluebird": "^3.3.4",
+    "mqtt": "4.2.x",
+    "serialport": "^9.0.3"
+  },
+  "nodemonConfig": {
+    "watch": [],
+    "ext": "js",
+    "ignore": [],
+    "exec": "RFLINK_DEBUG=true ~/npm/bin/homebridge -D -R -P ~/Code",
+    "signal": "SIGTERM",
+    "env": {
+      "NODE_OPTIONS": "--trace-warnings"
+    }
   }
 }

--- a/rflink.js
+++ b/rflink.js
@@ -1,5 +1,6 @@
 const SerialPort = require('serialport');
-const Readline = require('@serialport/parser-readline')
+const Readline = require('@serialport/parser-readline');
+const mqttClient = require('mqtt');
 const Promise = require('bluebird');
 var debug = process.env.hasOwnProperty('RFLINK_DEBUG') ? consoleDebug : function () {
 };
@@ -8,7 +9,9 @@ var debug = process.env.hasOwnProperty('RFLINK_DEBUG') ? consoleDebug : function
 const     DEFAULT_COMMAND_DELAY = 0,
           DEFAULT_COMMAND_REPEAT = 0,
           DEFAULT_DEVICE = '/dev/tty.usbmodemFA131',
-          DEFAULT_BAUDRATE = 57600;
+          DEFAULT_BAUDRATE = 57600,
+          DEFAULT_MQTTHOST = 'mqtt.local',
+          DEFAULT_MQTTTOPIC = 'RFLink/msg';
 
 //
 // Local helper functions
@@ -39,21 +42,32 @@ function settlePromises(promisesArray) {
  * @constructor
  */
 var RFLinkController = function (options, callback) {
+    debug('options', options);
     options = options || {};
 
+    this.mqttHost = options.mqttHost;
+    this.mqttTopic = options.mqttTopic || DEFAULT_MQTTTOPIC;
     this.device = options.device || DEFAULT_DEVICE;
     this._baudrate = options.baudrate || DEFAULT_BAUDRATE;
     this._delayBetweenCommands = options.delayBetweenCommands || DEFAULT_COMMAND_DELAY;
     this._commandRepeat = options.commandRepeat || DEFAULT_COMMAND_REPEAT;
     this._serialInit = Promise.resolve();
-    this._lastRequest = this._createSerial();
+    if (this.mqttHost) {
+      this._mqttInit = Promise.resolve();
+      this._lastRequest = this._createMqtt();
+    } else {
+      this._serialInit = Promise.resolve();
+      this._lastRequest = this._createSerial();
+    }
     this._sendRequest = Promise.resolve();
     this._dataHandler = callback;
     debug("RFLink:" + JSON.stringify({
         dev: this.device,
         baudrate: this._baudrate,
         delayBetweenCommands: this._delayBetweenCommands,
-        commandRepeat: this._commandRepeat
+        commandRepeat: this._commandRepeat,
+        mqttHost: this.mqttHost,
+        mqttTopic: this.mqttTopic
     }));
 };
 
@@ -202,5 +216,36 @@ RFLinkController.prototype.close = function () {
     }));
 };
 
+// Inital support for https://github.com/couin3/RFLink, temperature and humidty sensors only
+
+RFLinkController.prototype._createMqtt = function () {
+  var self = this;
+
+  return settlePromise(self._mqttInit).then(function () {
+
+      return (self._mqttInit = new Promise(function (resolve, reject) {
+          if (self.mqtt) {
+              return resolve();
+          }
+          else {
+              debug("Initializing MQTT Connection");
+              var options = {
+                username: self.mqttUsername || "",
+                password: self.mqttPassword || ""
+              }
+              self.mqtt = mqttClient.connect('mqtt://' + self.mqttHost, options);
+              self.mqtt.on('connect', function() {
+                debug('RFLink: mqtt connect');
+                self.mqtt.subscribe(self.mqttTopic);
+              });
+              self.mqtt.on('message', (topic, message) => {
+                debug("\nMessage: Topic %s -> %s", topic, message.toString());
+                self._dataHandler(message.toString());
+              });
+     
+          }
+      }));
+  });
+};
 
 module.exports = RFLinkController;


### PR DESCRIPTION
I have started switching my integration of 433Mhz devices into my homebridge environment from using a SDR plugged into a RPI to an ESP8266 with a 433Mhz receiver attached.  And for the ESP8266 side, I have used this firmware https://github.com/couin3/RFLink which offers Mqtt based connections.  This pull request adds support for read only Mqtt based sensors.

Also included is support for a Visual Studio based work flow, and the usage to nodemon to speed coding and testing.